### PR TITLE
updating pre-commit protocol and aicoe build-strategy

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -5,7 +5,7 @@ release:
   - upload-pypi-sesheta
 build:
   base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1
-  build-stratergy: Source
+  build-strategy: Source
   registry: quay.io
   registry-org: thoth-station
   registry-project: buildlog-parser

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
       - id: trailing-whitespace
@@ -21,7 +21,7 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: 5.1.1
     hooks:
       - id: pydocstyle


### PR DESCRIPTION
Using unencrypted version of the git protocol has been deprecated. Switching to HTTPS for pre-commit repos. Additionally updating the .aicoe-ci.yaml file with changing `build-stratergy` to `build-strategy`.

## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/2111